### PR TITLE
Enable Java time desugaring to prevent startup crash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,6 +32,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString() // "17"
@@ -95,4 +96,5 @@ dependencies {
     
     // WorkManager for background tasks
     implementation("androidx.work:work-runtime-ktx:2.9.1")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 }


### PR DESCRIPTION
## Summary
- Enable core library desugaring so java.time APIs work on Android 24–25
- Add desugaring dependency for java.time support

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c11da010832aae51e3a52daad136