### PR TITLE
Enable dynamic AI provider routing

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -73,7 +73,7 @@ CREATE TABLE weight_entries (
 
 ### Code Quality Metrics
 - **Starting TODOs**: 6 critical TODO items
-- **Remaining TODOs**: 2 (unrelated to main issues - Perplexity API routing)
+- **Remaining TODOs**: 0
 - **TODO Resolution**: 100% of targeted issues resolved
 - **Images Utilized**: 3 of 22 available images integrated strategically
 - **Build Status**: ✅ Successful compilation and APK generation

--- a/app/src/main/java/com/example/fitapp/ai/AiCore.kt
+++ b/app/src/main/java/com/example/fitapp/ai/AiCore.kt
@@ -62,24 +62,26 @@ class AiCore(private val context: Context, private val logDao: AiLogDao) {
     /**
      * Routes task to optimal AI provider based on task characteristics
      */
-    private fun selectProviderForTask(@Suppress("UNUSED_PARAMETER") task: TaskType, @Suppress("UNUSED_PARAMETER") hasImage: Boolean = false): AiProvider {
-        // Temporary: Route all requests through Gemini to avoid Perplexity-related crashes
-        // TODO: Restore original provider routing once Perplexity issues are resolved
-        return AiProvider.Gemini
-        
-        /* Original routing logic (disabled temporarily):
+    private fun selectProviderForTask(
+        task: TaskType,
+        hasImage: Boolean = false
+    ): AiProvider {
+        val perplexityAvailable = ApiKeys.isProviderAvailable(context, AiProvider.Perplexity)
+
         return when {
-            // Multimodal tasks → Gemini
+            // Multimodal tasks require Gemini's vision capabilities
             hasImage -> AiProvider.Gemini
-            // Structured fitness plans → Gemini  
+
+            // Structured fitness plans favour Gemini for consistency
             task == TaskType.TRAINING_PLAN -> AiProvider.Gemini
-            // Quick Q&A and web search → Perplexity
-            task == TaskType.SHOPPING_LIST_PARSING -> AiProvider.Perplexity
-            task == TaskType.RECIPE_GENERATION -> AiProvider.Perplexity
-            // Default to Gemini for complex tasks
+
+            // Lightweight tasks can use Perplexity when the key is configured
+            task == TaskType.SHOPPING_LIST_PARSING && perplexityAvailable -> AiProvider.Perplexity
+            task == TaskType.RECIPE_GENERATION && perplexityAvailable -> AiProvider.Perplexity
+
+            // Fallback to Gemini in all other cases or when Perplexity is unavailable
             else -> AiProvider.Gemini
         }
-        */
     }
 
     suspend fun generatePlan(req: PlanRequest): Result<String> {

--- a/app/src/main/java/com/example/fitapp/infrastructure/repositories/AiProviderRepositoryImpl.kt
+++ b/app/src/main/java/com/example/fitapp/infrastructure/repositories/AiProviderRepositoryImpl.kt
@@ -65,24 +65,30 @@ class AiProviderRepositoryImpl(
         return getProvider(provider)?.isAvailable() ?: false
     }
     
-    override suspend fun selectOptimalProvider(taskType: TaskType, hasImage: Boolean): com.example.fitapp.domain.entities.AiProvider {
-        // Temporary: Route all requests through Gemini to avoid Perplexity-related crashes
-        // TODO: Restore original provider routing once Perplexity issues are resolved
-        return com.example.fitapp.domain.entities.AiProvider.Gemini
-        
-        /* Original routing logic (disabled temporarily):
+    override suspend fun selectOptimalProvider(
+        taskType: TaskType,
+        hasImage: Boolean
+    ): com.example.fitapp.domain.entities.AiProvider {
+        val perplexityAvailable = isProviderAvailable(
+            com.example.fitapp.domain.entities.AiProvider.Perplexity
+        )
+
         return when {
-            // Multimodal tasks → Gemini
+            // Multimodal tasks always require Gemini's vision support
             hasImage -> com.example.fitapp.domain.entities.AiProvider.Gemini
-            // Structured fitness plans → Gemini  
+
+            // Structured fitness plans favour Gemini for longer responses
             taskType == TaskType.TRAINING_PLAN -> com.example.fitapp.domain.entities.AiProvider.Gemini
-            // Quick Q&A and web search → Perplexity
-            taskType == TaskType.SHOPPING_LIST_PARSING -> com.example.fitapp.domain.entities.AiProvider.Perplexity
-            taskType == TaskType.RECIPE_GENERATION -> com.example.fitapp.domain.entities.AiProvider.Perplexity
-            // Default to Gemini for complex tasks
+
+            // Route lightweight tasks to Perplexity when available
+            taskType == TaskType.SHOPPING_LIST_PARSING && perplexityAvailable ->
+                com.example.fitapp.domain.entities.AiProvider.Perplexity
+            taskType == TaskType.RECIPE_GENERATION && perplexityAvailable ->
+                com.example.fitapp.domain.entities.AiProvider.Perplexity
+
+            // Fallback to Gemini in all other cases or when Perplexity is unavailable
             else -> com.example.fitapp.domain.entities.AiProvider.Gemini
         }
-        */
     }
     
     override suspend fun getFallbackProvider(primary: com.example.fitapp.domain.entities.AiProvider): com.example.fitapp.domain.entities.AiProvider? {

--- a/app/src/test/java/com/example/fitapp/ai/CleanArchitectureTest.kt
+++ b/app/src/test/java/com/example/fitapp/ai/CleanArchitectureTest.kt
@@ -31,13 +31,13 @@ class CleanArchitectureVerification {
             val trainingProvider = mockRepository.selectOptimalProvider(TaskType.TRAINING_PLAN)
             if (trainingProvider != AiProvider.Gemini) return false
             
-            // Test recipe generation routing -> Gemini (temporarily, normally Perplexity)  
+            // Test recipe generation routing -> Perplexity when available
             val recipeProvider = mockRepository.selectOptimalProvider(TaskType.RECIPE_GENERATION)
-            if (recipeProvider != AiProvider.Gemini) return false
-            
-            // Test shopping list parsing routing -> Gemini (temporarily, normally Perplexity)
+            if (recipeProvider != AiProvider.Perplexity) return false
+
+            // Test shopping list parsing routing -> Perplexity when available
             val shoppingProvider = mockRepository.selectOptimalProvider(TaskType.SHOPPING_LIST_PARSING)
-            if (shoppingProvider != AiProvider.Gemini) return false
+            if (shoppingProvider != AiProvider.Perplexity) return false
             
             // Test image task routing -> Gemini
             val imageProvider = mockRepository.selectOptimalProvider(TaskType.CALORIE_ESTIMATION, hasImage = true)
@@ -104,25 +104,20 @@ class CleanArchitectureVerification {
  * Mock implementation for testing routing logic
  */
 private class MockAiProviderRepository {
-    
-    fun selectOptimalProvider(@Suppress("UNUSED_PARAMETER") taskType: TaskType, @Suppress("UNUSED_PARAMETER") hasImage: Boolean = false): AiProvider {
-        // Temporary: Route all requests through Gemini to avoid Perplexity-related crashes
-        // TODO: Restore original provider routing once Perplexity issues are resolved
-        return AiProvider.Gemini
-        
-        /* Original routing logic (disabled temporarily):
+
+    fun selectOptimalProvider(
+        taskType: TaskType,
+        hasImage: Boolean = false
+    ): AiProvider {
+        val perplexityAvailable = true
+
         return when {
-            // Multimodal tasks → Gemini
             hasImage -> AiProvider.Gemini
-            // Structured fitness plans → Gemini  
             taskType == TaskType.TRAINING_PLAN -> AiProvider.Gemini
-            // Quick Q&A and web search → Perplexity
-            taskType == TaskType.SHOPPING_LIST_PARSING -> AiProvider.Perplexity
-            taskType == TaskType.RECIPE_GENERATION -> AiProvider.Perplexity
-            // Default to Gemini for complex tasks
+            taskType == TaskType.SHOPPING_LIST_PARSING && perplexityAvailable -> AiProvider.Perplexity
+            taskType == TaskType.RECIPE_GENERATION && perplexityAvailable -> AiProvider.Perplexity
             else -> AiProvider.Gemini
         }
-        */
     }
     
     fun getFallbackProvider(primary: AiProvider): AiProvider? {


### PR DESCRIPTION
## Summary
- Reinstate original AI provider routing with runtime availability checks
- Update CleanArchitecture test expectations and mock repository
- Clarify implementation summary on remaining TODOs

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d9cba07c832ab047a81bc4bba2ba