### PR TITLE
Specify locales for string operations

### DIFF
--- a/app/src/main/java/com/example/fitapp/ai/AppAiClean.kt
+++ b/app/src/main/java/com/example/fitapp/ai/AppAiClean.kt
@@ -133,9 +133,9 @@ object AppAiClean {
             appendLine("Usage Statistics:")
             appendLine("- Total Requests: ${totalUsage.totalRequests}")
             appendLine("- Total Tokens: ${totalUsage.totalTokens}")
-            appendLine("- Estimated Cost: $${String.format(Locale.US, "%.3f", totalUsage.totalEstimatedCost)}")
-            appendLine("  - Gemini: ${totalUsage.geminiStats.requests} requests, ${totalUsage.geminiStats.tokens} tokens, $${String.format(Locale.US, "%.3f", totalUsage.geminiStats.estimatedCost)}")
-            appendLine("  - Perplexity: ${totalUsage.perplexityStats.requests} requests, ${totalUsage.perplexityStats.tokens} tokens, $${String.format(Locale.US, "%.3f", totalUsage.perplexityStats.estimatedCost)}")
+            appendLine("- Estimated Cost: $${String.format(Locale.GERMANY, "%.3f", totalUsage.totalEstimatedCost)}")
+            appendLine("  - Gemini: ${totalUsage.geminiStats.requests} requests, ${totalUsage.geminiStats.tokens} tokens, $${String.format(Locale.GERMANY, "%.3f", totalUsage.geminiStats.estimatedCost)}")
+            appendLine("  - Perplexity: ${totalUsage.perplexityStats.requests} requests, ${totalUsage.perplexityStats.tokens} tokens, $${String.format(Locale.GERMANY, "%.3f", totalUsage.perplexityStats.estimatedCost)}")
         }
     }
     

--- a/app/src/main/java/com/example/fitapp/data/repo/NutritionRepository.kt
+++ b/app/src/main/java/com/example/fitapp/data/repo/NutritionRepository.kt
@@ -135,7 +135,7 @@ class NutritionRepository(private val db: AppDatabase) {
     }
     
     private fun categorizeIngredient(ingredient: String): String {
-        val lowerIngredient = ingredient.lowercase()
+        val lowerIngredient = ingredient.lowercase(java.util.Locale.ROOT)
         return when {
             lowerIngredient.contains("fleisch") || lowerIngredient.contains("hähnchen") || 
             lowerIngredient.contains("rind") || lowerIngredient.contains("schwein") ||
@@ -243,7 +243,7 @@ class NutritionRepository(private val db: AppDatabase) {
             return 2000 // Default fallback
         }
 
-        val baselineKcal = when (latestPlan.goal.lowercase()) {
+        val baselineKcal = when (latestPlan.goal.lowercase(java.util.Locale.ROOT)) {
             "abnehmen", "gewicht verlieren" -> 1800
             "muskelaufbau", "masse aufbauen" -> 2500
             "kraft steigern" -> 2300

--- a/app/src/main/java/com/example/fitapp/infrastructure/logging/AiLogger.kt
+++ b/app/src/main/java/com/example/fitapp/infrastructure/logging/AiLogger.kt
@@ -33,7 +33,7 @@ class AiLogger(
         // Log to database
         aiLogDao.insert(
             AiLog.success(
-                taskType.name.lowercase(),
+                taskType.name.lowercase(java.util.Locale.ROOT),
                 provider.name,
                 prompt,
                 response,
@@ -52,7 +52,7 @@ class AiLogger(
         // Log to database
         aiLogDao.insert(
             AiLog.error(
-                taskType.name.lowercase(),
+                taskType.name.lowercase(java.util.Locale.ROOT),
                 provider.name,
                 prompt,
                 error,

--- a/app/src/main/java/com/example/fitapp/ui/nutrition/CookingModeScreen.kt
+++ b/app/src/main/java/com/example/fitapp/ui/nutrition/CookingModeScreen.kt
@@ -403,7 +403,7 @@ private fun parseIngredients(markdown: String): List<String> {
 }
 
 private fun categorizeIngredient(ingredient: String): String {
-    val lowercaseIngredient = ingredient.lowercase()
+    val lowercaseIngredient = ingredient.lowercase(java.util.Locale.ROOT)
     
     return when {
         // Fruits & Vegetables

--- a/app/src/main/java/com/example/fitapp/ui/nutrition/EnhancedShoppingListScreen.kt
+++ b/app/src/main/java/com/example/fitapp/ui/nutrition/EnhancedShoppingListScreen.kt
@@ -511,7 +511,7 @@ private suspend fun initializeDefaultCategories(db: AppDatabase) {
 }
 
 private fun categorizeItem(itemName: String): String {
-    val name = itemName.lowercase()
+    val name = itemName.lowercase(java.util.Locale.ROOT)
     return when {
         name.contains("apfel") || name.contains("banane") || name.contains("tomate") || 
         name.contains("zwiebel") || name.contains("karotte") || name.contains("salat") -> "Obst & Gemüse"

--- a/app/src/main/java/com/example/fitapp/ui/nutrition/NutritionScreen.kt
+++ b/app/src/main/java/com/example/fitapp/ui/nutrition/NutritionScreen.kt
@@ -333,7 +333,7 @@ suspend fun saveToSavedRecipes(context: Context, recipe: UiRecipe) {
     
     // Parse recipe details for better categorization
     val tags = mutableListOf<String>()
-    val markdown = recipe.markdown.lowercase()
+    val markdown = recipe.markdown.lowercase(java.util.Locale.ROOT)
     
     // Detect dietary tags
     if (markdown.contains("vegetarisch") || markdown.contains("vegetarian")) tags.add("vegetarian")
@@ -395,7 +395,7 @@ private fun extractPrepTime(markdown: String): Int? {
 
 private fun extractDifficulty(markdown: String): String? {
     val difficultyRegex = Regex("""(einfach|leicht|mittel|schwer|schwierig|easy|medium|hard)""", RegexOption.IGNORE_CASE)
-    return difficultyRegex.find(markdown)?.value?.lowercase()
+    return difficultyRegex.find(markdown)?.value?.lowercase(java.util.Locale.ROOT)
 }
 
 private fun extractServings(markdown: String): Int? {

--- a/app/src/main/java/com/example/fitapp/ui/screens/TrainingExecutionScreen.kt
+++ b/app/src/main/java/com/example/fitapp/ui/screens/TrainingExecutionScreen.kt
@@ -657,7 +657,7 @@ private fun calculateTotalDuration(exercises: List<ExerciseStep>): Int {
         totalMinutes += when (exercise.type) {
             "reps" -> 2 // 2 minutes per rep exercise
             "time" -> {
-                val timeStr = exercise.value.lowercase()
+                val timeStr = exercise.value.lowercase(java.util.Locale.ROOT)
                 when {
                     timeStr.contains("minute") -> timeStr.filter { it.isDigit() }.toIntOrNull() ?: 3
                     timeStr.contains("sekunde") -> (timeStr.filter { it.isDigit() }.toIntOrNull() ?: 30) / 60
@@ -674,8 +674,8 @@ private fun calculateTotalDuration(exercises: List<ExerciseStep>): Int {
 }
 
 private fun getCardioInstructions(exerciseName: String, exerciseValue: String): String {
-    val lowercaseName = exerciseName.lowercase()
-    val lowercaseValue = exerciseValue.lowercase()
+    val lowercaseName = exerciseName.lowercase(java.util.Locale.ROOT)
+    val lowercaseValue = exerciseValue.lowercase(java.util.Locale.ROOT)
     
     return when {
         lowercaseName.contains("laufband") || lowercaseName.contains("treadmill") -> {

--- a/app/src/main/java/com/example/fitapp/util/ApiCallWrapper.kt
+++ b/app/src/main/java/com/example/fitapp/util/ApiCallWrapper.kt
@@ -199,7 +199,7 @@ object ApiCallWrapper {
             is UnknownHostException -> true
             is ApiException -> exception.code in 500..599 || exception.code == 429 // Server errors and rate limiting
             else -> {
-                val message = exception.message?.lowercase()
+                val message = exception.message?.lowercase(java.util.Locale.ROOT)
                 message?.contains("timeout") == true ||
                 message?.contains("connection") == true ||
                 message?.contains("network") == true

--- a/app/src/main/java/com/example/fitapp/util/ErrorHandling.kt
+++ b/app/src/main/java/com/example/fitapp/util/ErrorHandling.kt
@@ -196,7 +196,7 @@ object ErrorHandling {
             is UnknownHostException,
             is TimeoutCancellationException -> true
             else -> {
-                val message = exception.message?.lowercase()
+                val message = exception.message?.lowercase(java.util.Locale.ROOT)
                 message?.contains("timeout") == true ||
                 message?.contains("connection") == true ||
                 message?.contains("network") == true


### PR DESCRIPTION
## Summary
- use Locale.ROOT for lowercase operations
- format cost strings with Locale.GERMANY

## Testing
- `./gradlew clean assembleDebug` *(fails: Cannot find a Java installation)*
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b52062e4bc832aaf73a02da679087a