### PR TITLE
Fix root build script causing Gradle configuration error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,9 +4,4 @@ plugins {
     id("org.jetbrains.kotlin.plugin.serialization") version "2.0.20" apply false
     id("com.google.devtools.ksp") version "2.0.20-1.0.25" apply false
 }
-android {
-    buildFeatures {
-        mlModelBinding = true
-    }
-}
 


### PR DESCRIPTION
## Summary
- remove misplaced `android` block from top-level `build.gradle.kts`

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_68bc1341b384832aa56c4cfa2b4fdd21