### PR TITLE
fix: align serialization with Kotlin 2.0

### DIFF
--- a/DEPENDENCY_UPDATES.md
+++ b/DEPENDENCY_UPDATES.md
@@ -16,7 +16,7 @@ This document summarizes the dependency version updates made to address Dependab
 
 | Dependency | Proposed Version | Reason for Not Updating |
 |------------|------------------|-------------------------|
-| `kotlinx-serialization-json` | 1.9.0 | Requires Kotlin 2.2.0, but project uses 2.0.20 |
+| `kotlinx-serialization-json` | 1.9.0 (reverted to 1.7.3) | Requires Kotlin 2.2.0, but project uses 2.0.20 |
 | `com.android.application` | 8.13.0 | Would require broader testing due to AGP changes |
 | `com.google.devtools.ksp` | 2.2.10-2.0.2 | Incompatible with current Kotlin version |
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,10 @@
 [versions]
 kotlin = "2.0.20"
 agp = "8.13.0"
-serialization = "1.9.0"
+# kotlinx-serialization 1.9.0 targets Kotlin 2.2, which is incompatible
+# with the project's Kotlin 2.0.20 setup. Downgrade to the latest
+# version built for Kotlin 2.0 to resolve metadata version conflicts.
+serialization = "1.7.3"
 
 # Versioning
 axion-release = "1.18.12"


### PR DESCRIPTION
## Summary
- revert kotlinx-serialization to 1.7.3 for Kotlin 2.0 compatibility
- document serialization rollback in dependency updates

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc0178b40832abd3b9b7fdb3fb047