### PR TITLE
Fix test dependency references

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -242,9 +242,9 @@ dependencies {
     // (Bereinigt) – Duplikate entfernt
     debugImplementation("androidx.compose.ui:ui-test-manifest:1.9.0")
     testImplementation(libs.junit)
-    testImplementation(libs.coroutines_test)
+    testImplementation(libs.coroutines.test)
     testImplementation(libs.robolectric)
-    testImplementation(libs.mockito_core)
+    testImplementation(libs.mockito.core)
 }
 
 // Jacoco


### PR DESCRIPTION
## Summary
- correct version catalog references for coroutines test and mockito dependencies

## Testing
- `./gradlew :app:testDebugUnitTest --stacktrace` *(fails: Expecting member declaration in GeminiAiProvider.kt)*

------
https://chatgpt.com/codex/tasks/task_e_68bd80c75e64832a848c8ae07c0c97c5