### PR TITLE
Fix Hilt application generation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
+    id("org.jetbrains.kotlin.kapt")
     alias(libs.plugins.hilt)
     alias(libs.plugins.protobuf)
 }
@@ -81,6 +82,10 @@ android {
     }
 }
 
+kapt {
+    correctErrorTypes = true
+}
+
 dependencies {
     val composeBom = platform(libs.compose.bom)
     implementation(composeBom)
@@ -139,7 +144,7 @@ dependencies {
     // Hilt Dependency Injection
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)
-    ksp(libs.hilt.compiler)
+    kapt(libs.hilt.compiler)
 
     // Desugaring
     coreLibraryDesugaring(libs.desugar.jdk.libs)

--- a/local.properties
+++ b/local.properties
@@ -1,1 +1,1 @@
-sdk.dir=/workspaces/FitApp/android-sdk
+sdk.dir=android-sdk


### PR DESCRIPTION
## Summary
- add kapt for Hilt and enable error type correction
- use relative Android SDK path for local builds

## Testing
- `./gradlew -p app assembleDebug` *(fails: build incomplete due to environment limits)*
- `./gradlew -p app help`


------
https://chatgpt.com/codex/tasks/task_e_68c08617ea48832a98ed9a7ba0f9d967